### PR TITLE
Enrichment Genes Column (#83)

### DIFF
--- a/global.R
+++ b/global.R
@@ -725,20 +725,37 @@ FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInf
 
   # given a pathway id, it finds the overlapped genes, symbol preferred
   sharedGenesPrefered <- function(pathwayID) {
-    tem <- result[which(result[, 2] == pathwayID), 1]
-    ix <- match(tem, converted$conversionTable$ensembl_gene_id) # convert back to original
-    tem2 <- unique(converted$conversionTable$User_input[ix])
+    # result comes from "select distinct gene, pathwayID", so this is already
+    # one row per gene and the output must have exactly one token per gene.
+    # enrichmentPlot() and enrichmentNetwork() rebuild pathway membership by
+    # splitting this string on spaces, so dropping a gene here silently
+    # corrupts the tree and network overlaps as well as the displayed table.
+    ens <- result[which(result[, 2] == pathwayID), 1]
+
+    # Default to the IDs the user pasted, mapped back from Ensembl.
+    out <- converted$conversionTable$User_input[
+      match(ens, converted$conversionTable$ensembl_gene_id)
+    ]
+
     if (!is.null(gInfo)) {
-      if (class(gInfo) == "data.frame") {
-        if (dim(gInfo)[1] > 1) {
-          if (length(unique(gInfo$symbol)) / dim(gInfo)[1] > .7) { # if 70% genes has symbol in geneInfo
-            ix <- match(tem, gInfo$ensembl_gene_id)
-            tem2 <- unique(gInfo$symbol[ix])
+      if (is.data.frame(gInfo)) {
+        if (nrow(gInfo) > 1) {
+          if (length(unique(gInfo$symbol)) / nrow(gInfo) > .7) { # if 70% genes has symbol in geneInfo
+            # Substitute per gene rather than wholesale: species like maize
+            # have symbols for only some genes, and the rest are blank.
+            sym <- gInfo$symbol[match(ens, gInfo$ensembl_gene_id)]
+            has_symbol <- !is.na(sym) & nzchar(sym)
+            out[has_symbol] <- sym[has_symbol]
           }
         }
       }
     }
-    return(paste(tem2, collapse = " ", sep = ""))
+
+    # Last resort, so a gene is never represented by an empty token.
+    unnamed <- is.na(out) | !nzchar(out)
+    out[unnamed] <- ens[unnamed]
+
+    return(paste(out, collapse = " "))
   }
 
   x0 <- table(result$pathwayID)


### PR DESCRIPTION
Fixes the data-loss half of #83. One file, `global.R`, +26 −9.

### What was reported

Two maize gene lists submitted to 0.85.1 with `zmays_eg_gene`. The first came
back with Ensembl IDs in the enrichment table's Genes column, the second with a
mix of symbols and other identifiers. 0.82 gave Ensembl IDs for both.

### What is actually wrong

While looking into the ID type I found a second and more serious problem in the
same function: **the Genes column has been silently dropping genes.**

`sharedGenesPrefered()` in `FindOverlap()` did this:

```r
ix   <- match(tem, gInfo$ensembl_gene_id)
tem2 <- unique(gInfo$symbol[ix])
```

`result` comes from `select distinct gene, pathwayID`, so `tem` is already one
row per gene. But `gInfo$symbol` is not unique. For species where only some genes
carry a symbol, every unsymboled gene in a pathway collapses into a single empty
token, and genes sharing a symbol collapse into one. `nGenes` stays correct while
the list of genes beside it does not — which is also where the leading and
doubled spaces in the exported tables come from.

This is not only a display problem. `enrichmentPlot()` (`global.R:1062`) and
`enrichmentNetwork()` both rebuild pathway membership by splitting that same
string on spaces:

```r
geneLists <- lapply(enrichedTerms$Genes, function(x) unlist(strsplit(as.character(x), " ")))
```

So for any species where the symbol branch fires, the clustering tree and the
network Jaccard overlaps have been computed on truncated gene sets containing
phantom empty members.

### The fix

Substitute per gene rather than replacing the whole vector, and never emit an
empty token:

- keep the pasted ID for genes that have no usable symbol
- fall back to the Ensembl ID if there is no pasted ID either
- drop `unique()`, so the token count equals `nGenes` by construction

Also swaps `class(gInfo) == "data.frame"` for `is.data.frame(gInfo)`. The former
returns a length-3 vector for a tibble, which errors inside `if()` on R >= 4.2.

### Verification

Reproduced against a local database built with maize-shaped sparse symbols —
most genes symbol-less, one duplicated symbol pair, ratio above the 0.7 threshold
so the symbol branch fires:

| | rows where tokens != nGenes | strings with blank tokens |
|---|---|---|
| before | 4 of 8 | 4 |
| after | 0 of 8 | 0 |

After the fix the gene lists that `enrichmentPlot()`/`enrichmentNetwork()` parse
back out match `nGenes` exactly. The branch that echoes pasted IDs when the ratio
is below 0.7 was checked too, and the app starts clean.

Enrichment statistics are unaffected either way: FDRs and gene counts are computed
upstream from internal Ensembl IDs, never from this string.

### Not changed here

The `> .7` rule that decides symbols vs pasted IDs is untouched in this PR. That
is the other half of #83 and it changes behaviour, so it is the follow-up:
`feat-83-genes-column-id-type`.

Two things about that rule are worth knowing, because they explain the report.

**It measures the user's own gene list, not the genome.** `server.R:264` filters
`gInfo` down to the submitted genes before calling `FindOverlap()`:

```r
tem <- geneInfoLookup()
tem <- tem[which(tem$Set == "List"), ]
```

So the ratio is "how many of the genes you pasted have distinct symbols". A well
annotated list lands above 0.7 and gets symbols; a sparsely annotated one falls
below and gets pasted IDs. Same species, different answer. Measured on a test
database: 1.0 for a well annotated list, 0.667 for a sparse one — exactly the
reporter's two outcomes.

**The 0.82 -> 0.85.1 difference was not a code change.** I diffed it:
`sharedGenesPrefered()` and the `Set == "List"` call site are byte for byte
identical in `2d0f2cf` (version 0.82) and on `v851pfe`. Their genes must have
gained symbols in a database rebuild and crossed the threshold. The same can
happen to any species on any future rebuild.

### Separately, for the database build

For maize the `symbol` column itself appears to hold Entrez gene IDs as filler
(`100191838`), uniquification suffixes (`TPIS_0`, `RPL6_6`), and at least one
rice locus ID. Those are not gene symbols, so a user joining that column against
their own annotation will silently lose rows. No code change reaches this; it
belongs in how the database is built — fall back to the Ensembl gene ID rather
than the Entrez ID, and keep the suffixes out of a display field. I would not
strip `_[0-9]+$` at display time, since that would mangle genes whose real names
end in a digit.