### PR TITLE
Let users choose what the Genes column contains (#83)

### DIFF
--- a/global.R
+++ b/global.R
@@ -641,7 +641,13 @@ hyperText <- function(textVector, urlVector) {
 
 # Main function. Find a query set of genes enriched with functional category
 # For debug:  converted = converted(); gInfo = tem;  GO=input$selectGO; selectOrg=input$selectOrg;  minFDR=input$minFDR; input_maxTerms=input$maxTerms
-FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInfoB = NULL, minSetSize = 2, maxSetSize = 4000, gene_count_pathwaydb = FALSE) {
+FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInfoB = NULL, minSetSize = 2, maxSetSize = 4000, gene_count_pathwaydb = FALSE, genes_column = "symbol") {
+  # genes_column controls what the Genes column holds: "symbol" (gene symbols
+  # where the database has one, otherwise the pasted ID), "input" (the IDs the
+  # user pasted) or "ensembl". NULL can arrive before the input has rendered.
+  if (is.null(genes_column) || !genes_column %in% c("symbol", "input", "ensembl")) {
+    genes_column <- "symbol"
+  }
   minFDR <- 0.2 # internal cutoff; avoids passing a large number of pathways
   maxTerms <- 1000 # only keep 1000 pathways at the most
 
@@ -732,17 +738,18 @@ FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInf
     # corrupts the tree and network overlaps as well as the displayed table.
     ens <- result[which(result[, 2] == pathwayID), 1]
 
-    # Default to the IDs the user pasted, mapped back from Ensembl.
-    out <- converted$conversionTable$User_input[
+    pasted <- converted$conversionTable$User_input[
       match(ens, converted$conversionTable$ensembl_gene_id)
     ]
 
-    if (!is.null(gInfo)) {
-      if (is.data.frame(gInfo)) {
-        if (nrow(gInfo) > 1) {
-          if (length(unique(gInfo$symbol)) / nrow(gInfo) > .7) { # if 70% genes has symbol in geneInfo
-            # Substitute per gene rather than wholesale: species like maize
-            # have symbols for only some genes, and the rest are blank.
+    out <- if (genes_column == "ensembl") ens else pasted
+
+    if (genes_column == "symbol") {
+      # Substitute per gene rather than wholesale: species like maize have
+      # symbols for only some genes, and the rest are blank.
+      if (!is.null(gInfo)) {
+        if (is.data.frame(gInfo)) {
+          if (nrow(gInfo) > 1) {
             sym <- gInfo$symbol[match(ens, gInfo$ensembl_gene_id)]
             has_symbol <- !is.na(sym) & nzchar(sym)
             out[has_symbol] <- sym[has_symbol]

--- a/server.R
+++ b/server.R
@@ -122,7 +122,7 @@ server <- function(input, output, session) {
           paste(
             "No gene information found for these genes in",
             findSpeciesByIdName(input$selectOrg),
-            "- please check that the selected species is correct."
+            "- please check that the selected species is correct. Reset and try again."
           ),
           id = "species_mismatch",
           type = "warning",
@@ -1006,12 +1006,51 @@ server <- function(input, output, session) {
     }
   )
 
+  # Ask what the Genes column should contain, then hand over the real download
+  # button. The Genes column is not part of the on-screen table, so this is the
+  # only point where the choice is visible to the user.
+  genes_column_dialog <- function(download_id, title) {
+    shiny::modalDialog(
+      title = title,
+      radioButtons(
+        inputId = "genesColumnID",
+        label = "How should genes be listed in the Genes column?",
+        choiceNames = c(
+          "Gene symbols where available, otherwise the ID you pasted",
+          "The gene IDs you pasted",
+          "Ensembl gene IDs"
+        ),
+        choiceValues = c("symbol", "input", "ensembl"),
+        selected = if (is.null(input$genesColumnID)) "symbol" else input$genesColumnID
+      ),
+      helpText(
+        "Some species have gene symbols for only part of the genome. For those,
+         the first option gives a mix of symbols and IDs. Choose one of the other
+         two if you need a single consistent ID type."
+      ),
+      footer = tagList(
+        modalButton("Cancel"),
+        downloadButton(download_id, "Download")
+      ),
+      easyClose = TRUE
+    )
+  }
+
+  observeEvent(input$askDownloadEnrichment, {
+    showModal(genes_column_dialog("downloadEnrichment", "Download top pathways"))
+  })
+
+  observeEvent(input$askDownloadEnrichmentAll, {
+    showModal(genes_column_dialog("downloadEnrichmentAll", "Download all pathways"))
+  })
+
   output$downloadEnrichment <- downloadHandler(
     filename = function() {
       "enrichment.csv"
     },
     content = function(file) {
       write.csv(significantOverlaps()$x, file, row.names = FALSE)
+      removeModal()
     }
   )
 
@@ -1021,6 +1060,7 @@ server <- function(input, output, session) {
     },
     content = function(file) {
       write.csv(significantOverlapsAll()$x, file, row.names = FALSE)
+      removeModal()
     }
   )
 

--- a/server.R
+++ b/server.R
@@ -257,6 +257,9 @@ server <- function(input, output, session) {
     tem <- input$gene_count_pathwaydb
     tem <- input$minSetSize
     tem <- input$maxSetSize
+    # Must be read outside the isolate() below, or changing it never
+    # invalidates this reactive and the Genes column silently never updates.
+    tem <- input$genesColumnID
 
     isolate({
       withProgress(message = sample(quotes, 1), detail = "enrichment analysis", {
@@ -270,7 +273,8 @@ server <- function(input, output, session) {
         enrichment <- FindOverlap(converted(), tem, input$selectGO, input$selectOrg,
           converted_background(), temb,
           minSetSize = input$minSetSize, maxSetSize = input$maxSetSize,
-          gene_count_pathwaydb = input$gene_count_pathwaydb
+          gene_count_pathwaydb = input$gene_count_pathwaydb,
+          genes_column = input$genesColumnID
         )
         return(enrichment)
       })

--- a/server.R
+++ b/server.R
@@ -105,11 +105,30 @@ server <- function(input, output, session) {
     # remove ensembl gene IDs mapped to the same gene (marked as duplicated in gene info)
     if(as.numeric(input$selectOrg) > 0) { # if it is ENSEMBL, not STRING species
       gene_info <- geneInfo(converted, input$selectOrg)
-      converted$IDs <- gene_info |>
-        filter(!duplicated) |>
-        filter(ensembl_gene_id %in% converted$IDs) |>
-        pull(ensembl_gene_id)
-      #conversionTable is not changed. Not unique.
+
+      # geneInfo() returns a single-column "ID not recognized!" frame when
+      # nothing maps, most often because the gene list and the selected species
+      # do not match. That frame has no `duplicated` column, so filter(!duplicated)
+      # resolves to base::duplicated and aborts the reactive, taking every
+      # downstream tab with it. Warn and carry on instead.
+      if (is.data.frame(gene_info) && "duplicated" %in% colnames(gene_info)) {
+        converted$IDs <- gene_info |>
+          filter(!duplicated) |>
+          filter(ensembl_gene_id %in% converted$IDs) |>
+          pull(ensembl_gene_id)
+        #conversionTable is not changed. Not unique.
+      } else {
+        showNotification(
+          paste(
+            "No gene information found for these genes in",
+            findSpeciesByIdName(input$selectOrg),
+            "- please check that the selected species is correct."
+          ),
+          id = "species_mismatch",
+          type = "warning",
+          duration = 15
+        )
+      }
     }
     converted
 

--- a/ui.R
+++ b/ui.R
@@ -320,49 +320,34 @@ ui <- fluidPage(
           br(),
           conditionalPanel(
             "input.goButton != 0",
-            # Flex row: the two controls belong side by side. The sort input
-            # used to carry style= twice ("display:inline-block" and a typo'd
-            # "algn:right"); htmltools joins duplicate attributes, so the
-            # display rule was invalid and the div fell back to block.
+            # The sort input used to carry style= twice ("display:inline-block"
+            # and a typo'd "algn:right"); htmltools joins duplicate attributes,
+            # so the display rule was invalid and the div fell back to block.
             div(
-              style = "display:flex; flex-wrap:wrap; gap:12px; align-items:center",
-              div(
-                style = "display:inline-block",
-                selectInput(
-                  inputId = "SortPathways",
-                  label = NULL,
-                  choices = c(
-                    "Sort by FDR" = "Sort by FDR",
-                    "Sort by Fold Enrichment" = "Sort by Fold Enrichment",
-                    "Sort by average ranks(FDR & Fold)" = "Sort by FDR & Fold Enrichment",
-                    "Select by FDR, sort by Fold Enrichment" = "Select by FDR, sort by Fold Enrichment",
-                    "Sort by Genes" = "Sort by Genes",
-                    "Sort by Category Name" = "Sort by Category Name"
-                  ),
-                  selected = "Select by FDR, sort by Fold Enrichment"
-                )
-              ),
-              div(
-                style = "display:inline-block",
-                selectInput(
-                  inputId = "genesColumnID",
-                  label = NULL,
-                  choices = c(
-                    "Genes column: symbols when available" = "symbol",
-                    "Genes column: IDs you pasted" = "input",
-                    "Genes column: Ensembl IDs" = "ensembl"
-                  ),
-                  selected = "symbol",
-                  width = "320px"
-                )
+              style = "display:inline-block",
+              selectInput(
+                inputId = "SortPathways",
+                label = NULL,
+                choices = c(
+                  "Sort by FDR" = "Sort by FDR",
+                  "Sort by Fold Enrichment" = "Sort by Fold Enrichment",
+                  "Sort by average ranks(FDR & Fold)" = "Sort by FDR & Fold Enrichment",
+                  "Select by FDR, sort by Fold Enrichment" = "Select by FDR, sort by Fold Enrichment",
+                  "Sort by Genes" = "Sort by Genes",
+                  "Sort by Category Name" = "Sort by Category Name"
+                ),
+                selected = "Select by FDR, sort by Fold Enrichment"
               )
             )
           ),
           tableOutput("EnrichmentTable"),
           conditionalPanel(
             "input.goButton != 0",
-            downloadButton("downloadEnrichment", "Top Pathways shown above"),
-            downloadButton("downloadEnrichmentAll", "Results on all Pathways"),
+            # These open a dialog to pick what the Genes column should hold,
+            # then offer the real download. The Genes column is not shown in
+            # the table above, so the choice only makes sense at download time.
+            actionButton("askDownloadEnrichment", "Top Pathways shown above", icon = icon("download")),
+            actionButton("askDownloadEnrichmentAll", "Results on all Pathways", icon = icon("download")),
             br(), br(),
             h3("Methods"),
             p("All query genes are converted to ENSEMBL gene IDs or STRING-db protein IDs,

--- a/ui.R
+++ b/ui.R
@@ -336,6 +336,20 @@ ui <- fluidPage(
                 selected = "Select by FDR, sort by Fold Enrichment"
               ),
               style = "algn:right"
+            ),
+            div(
+              style = "display:inline-block; margin-left:12px; vertical-align:top",
+              selectInput(
+                inputId = "genesColumnID",
+                label = NULL,
+                choices = c(
+                  "Genes column: symbols when available" = "symbol",
+                  "Genes column: IDs you pasted" = "input",
+                  "Genes column: Ensembl IDs" = "ensembl"
+                ),
+                selected = "symbol",
+                width = "320px"
+              )
             )
           ),
           tableOutput("EnrichmentTable"),

--- a/ui.R
+++ b/ui.R
@@ -320,35 +320,41 @@ ui <- fluidPage(
           br(),
           conditionalPanel(
             "input.goButton != 0",
+            # Flex row: the two controls belong side by side. The sort input
+            # used to carry style= twice ("display:inline-block" and a typo'd
+            # "algn:right"); htmltools joins duplicate attributes, so the
+            # display rule was invalid and the div fell back to block.
             div(
-              style = "display:inline-block",
-              selectInput(
-                inputId = "SortPathways",
-                label = NULL,
-                choices = c(
-                  "Sort by FDR" = "Sort by FDR",
-                  "Sort by Fold Enrichment" = "Sort by Fold Enrichment",
-                  "Sort by average ranks(FDR & Fold)" = "Sort by FDR & Fold Enrichment",
-                  "Select by FDR, sort by Fold Enrichment" = "Select by FDR, sort by Fold Enrichment",
-                  "Sort by Genes" = "Sort by Genes",
-                  "Sort by Category Name" = "Sort by Category Name"
-                ),
-                selected = "Select by FDR, sort by Fold Enrichment"
+              style = "display:flex; flex-wrap:wrap; gap:12px; align-items:center",
+              div(
+                style = "display:inline-block",
+                selectInput(
+                  inputId = "SortPathways",
+                  label = NULL,
+                  choices = c(
+                    "Sort by FDR" = "Sort by FDR",
+                    "Sort by Fold Enrichment" = "Sort by Fold Enrichment",
+                    "Sort by average ranks(FDR & Fold)" = "Sort by FDR & Fold Enrichment",
+                    "Select by FDR, sort by Fold Enrichment" = "Select by FDR, sort by Fold Enrichment",
+                    "Sort by Genes" = "Sort by Genes",
+                    "Sort by Category Name" = "Sort by Category Name"
+                  ),
+                  selected = "Select by FDR, sort by Fold Enrichment"
+                )
               ),
-              style = "algn:right"
-            ),
-            div(
-              style = "display:inline-block; margin-left:12px; vertical-align:top",
-              selectInput(
-                inputId = "genesColumnID",
-                label = NULL,
-                choices = c(
-                  "Genes column: symbols when available" = "symbol",
-                  "Genes column: IDs you pasted" = "input",
-                  "Genes column: Ensembl IDs" = "ensembl"
-                ),
-                selected = "symbol",
-                width = "320px"
+              div(
+                style = "display:inline-block",
+                selectInput(
+                  inputId = "genesColumnID",
+                  label = NULL,
+                  choices = c(
+                    "Genes column: symbols when available" = "symbol",
+                    "Genes column: IDs you pasted" = "input",
+                    "Genes column: Ensembl IDs" = "ensembl"
+                  ),
+                  selected = "symbol",
+                  width = "320px"
+                )
               )
             )
           ),


### PR DESCRIPTION
Answers the second half of #83. Three files, +94 −19.

### Why the reporter saw two different answers

The `> .7` rule choosing between gene symbols and pasted IDs didn't do what its comment claimed. `server.R:264` filters `gInfo` to the submitted genes before `FindOverlap()` runs:

```r
tem <- geneInfoLookup()
tem <- tem[which(tem$Set == "List"), ]
```

So the ratio measured *the user's gene list*, not the species. Well-annotated lists cross 0.7 and get symbols; sparse ones don't. Same species, different ID type. On a test database: 1.0 vs 0.667.

`sharedGenesPrefered()` and its call site are byte-identical in `2d0f2cf` (v0.82), so nothing changed in code — the reporter's maize genes gained symbols in a database rebuild and crossed the threshold.

### The change

Both Enrichment tab download buttons now open a dialog asking how genes should be listed: symbols where available (default), pasted IDs, or Ensembl IDs, with the download button in the footer.

A dialog rather than a tab control because the Genes column isn't in the on-screen table (`output$EnrichmentTable` drops it via `pathways[, -7]`), so a tab control would look broken — you'd change it and see nothing move.

`FindOverlap()` gains a `genes_column` argument, one call site, falling back to `"symbol"` on `NULL` or unrecognised values. Behaviour before the dialog is ever opened is unchanged.

### Also in this branch

**Crash on species mismatch.** `geneInfo()` returns a single-column "ID not recognized!" frame when nothing maps, so `filter(!duplicated)` in `converted()` resolved to `base::duplicated` and errored, taking down every dependent output. Now guarded, with a notification naming the selected species.

**Layout bug.** The sort input had `style=` twice (`"display:inline-block"` and a typo'd `"algn:right"`); htmltools joins duplicates, producing invalid CSS, so the div rendered as a block.

### Verification

`shiny::testServer` against the real `server`, on a database with maize-shaped sparse symbols:

- all three settings produce different Genes columns, one token per gene, count matching `nGenes`
- `NULL` behaves as `"symbol"`
- maize list against Human returns `NULL` instead of aborting; matching case still resolves and switches format

Manually: all tabs render for maize and human; tree and network keep structure across all three settings.

### Three caveats

**Changing the setting re-runs enrichment**, since the Genes string is built inside `FindOverlap()` — a progress bar between choosing and downloading. Avoiding it means retaining the Ensembl-to-symbol mapping and reformatting at write time; more code for a rarely changed setting.

**The setting isn't purely cosmetic.** `enrichmentPlot()` computes overlap as `length(intersect(u, v)) / length(unique(c(u, v)))`, and both de-duplicate. With paralogs sharing a symbol, symbol mode sees one element where Ensembl sees two, so tree/network overlaps can differ slightly. Narrow, and better than before (where `unique()` collapsed more) — but it argues for a good default.

**The default.** I kept "symbols where available" to preserve current behaviour for well-annotated species, which assumes human and mouse are nearly all symboled. If it's low, more human genes than expected show mixed IDs under the default, and "pasted IDs" may be better.