### PR TITLE
Use returned membership instead of parsing Genes

### DIFF
--- a/global.R
+++ b/global.R
@@ -735,6 +735,14 @@ FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInf
 
 
   # given a pathway id, it finds the overlapped genes, symbol preferred
+  # Actual pathway membership, as Ensembl ids. This is what the tree, the
+  # network and the redundancy filter need. sharedGenesPrefered() below formats
+  # the same thing for display; nothing should parse that string to recover
+  # membership, because then display formatting changes the analysis.
+  pathwayMembers <- function(pathwayID) {
+    result[which(result[, 2] == pathwayID), 1]
+  }
+
   sharedGenesPrefered <- function(pathwayID) {
     # result comes from "select distinct gene, pathwayID", so this is already
     # one row per gene and the output must have exactly one token per gene.
@@ -956,11 +964,14 @@ FindOverlap <- function(converted, gInfo, GO, selectOrg, convertedB = NULL, gInf
     x <- cbind(x, sapply(x$pathwayID, sharedGenesPrefered))
 
     colnames(x)[9] <- "Genes"
+    # I() keeps this an AsIs list column so it survives ordering and subsetting
+    # below and stays aligned with its row.
+    x$Membership <- I(lapply(x$pathwayID, pathwayMembers))
     x$n <- as.numeric(x$n) # convert total genes from character to numeric 10/21/19
-    x <- subset(x, select = c(FDR, overlap, n, fold, description, memo, Genes))
+    x <- subset(x, select = c(FDR, overlap, n, fold, description, memo, Genes, Membership))
     x <- x[order(x$FDR), ] # sort by FDR   4/1/2022 related to issue 23
     x <- x[!duplicated(x$description), ] # remove duplicates   4/1/2022
-    colnames(x) <- c("Enrichment FDR", "nGenes", "Pathway Genes", "Fold Enrichment", "Pathway", "URL", "Genes")
+    colnames(x) <- c("Enrichment FDR", "nGenes", "Pathway Genes", "Fold Enrichment", "Pathway", "URL", "Genes", "Membership")
 
 
 
@@ -1070,7 +1081,10 @@ enrichmentPlot <- function(enrichedTerms, rightMargin = 33) {
   } # only one term or less
   library(dendextend) # customizing tree
 
-  geneLists <- lapply(enrichedTerms$Genes, function(x) unlist(strsplit(as.character(x), " ")))
+  # Membership comes from FindOverlap() as Ensembl ids. Do not go back to
+  # splitting enrichedTerms$Genes: that column is formatted for display, and
+  # parsing it makes formatting changes move these numbers.
+  geneLists <- lapply(enrichedTerms$Membership, as.character)
   names(geneLists) <- enrichedTerms$Pathways
 
   # compute overlaps percentage--------------------
@@ -1286,7 +1300,10 @@ enrich.net2 <- function(x, gene.set, node.id, node.name = node.id, pvalue,
 }
 
 enrichmentNetwork <- function(enrichedTerms, layoutButton = 0, edge.cutoff = 5) {
-  geneLists <- lapply(enrichedTerms$Genes, function(x) unlist(strsplit(as.character(x), " ")))
+  # Membership comes from FindOverlap() as Ensembl ids. Do not go back to
+  # splitting enrichedTerms$Genes: that column is formatted for display, and
+  # parsing it makes formatting changes move these numbers.
+  geneLists <- lapply(enrichedTerms$Membership, as.character)
   names(geneLists) <- enrichedTerms$Pathways
   enrichedTerms$Direction <- gsub(" .*", "", enrichedTerms$Direction)
 

--- a/server.R
+++ b/server.R
@@ -383,11 +383,10 @@ server <- function(input, output, session) {
         if (reduced != FALSE && dim(enrichment$x)[1] > 5) {
           n <- nrow(enrichment$x)
           flag1 <- rep(TRUE, n)
-          # note that it has to be two space characters for splitting
-          geneLists <- lapply(
-            enrichment$x$Genes,
-            function(y) unlist(strsplit(as.character(y), " |  |   "))
-          )
+          # Membership as Ensembl ids, straight from FindOverlap(). The old
+          # split on " |  |   " was a workaround for parsing the display
+          # string; there is nothing to parse now.
+          geneLists <- lapply(enrichment$x$Membership, as.character)
           pathways <- lapply(
             enrichment$x$Pathway,
             function(y) unlist(strsplit(as.character(y), " |  |   "))
@@ -731,6 +730,7 @@ server <- function(input, output, session) {
         }
         pathways$Pathway <- hyperText(pathways$Pathway, pathways$URL)
 
+        pathways$Membership <- NULL # internal, never displayed
         pathways <- pathways[, -7]
         # rownames(pathways) <- NULL
         # pathways[, 1] <- as.numeric( format(pathways[, 1], scientific = TRUE, digits = 3 ) )
@@ -770,7 +770,7 @@ server <- function(input, output, session) {
       return(NULL)
     }
     tem <- tem$x
-    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes")
+    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes", "Membership")
     tem$Pathways <- gsub(".*'_blank'>|</a>", "", tem$Pathways) # remove URL
     tem$Direction <- "Diff"
     # remove pathway ID  only in Ensembl species
@@ -792,7 +792,7 @@ server <- function(input, output, session) {
       return(NULL)
     }
     tem <- tem$x
-    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes")
+    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes", "Membership")
     tem$Pathways <- gsub(".*'_blank'>|</a>", "", tem$Pathways) # remove URL
 
     # remove pathway ID  only in Ensembl species
@@ -819,7 +819,7 @@ server <- function(input, output, session) {
       return(NULL)
     }
     tem <- tem$x
-    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes")
+    colnames(tem) <- c("adj.Pval", "nGenesList", "nGenesCategor", "Fold", "Pathways", "URL", "Genes", "Membership")
     tem$Pathways <- gsub(".*'_blank'>|</a>", "", tem$Pathways) # remove URL
 
     # remove pathway ID  only in Ensembl species
@@ -1047,12 +1047,19 @@ server <- function(input, output, session) {
     showModal(genes_column_dialog("downloadEnrichmentAll", "Download all pathways"))
   })
 
+  # Membership is a list column carried for the tree, network and redundancy
+  # filter. It is internal, and write.csv cannot serialise it.
+  drop_membership <- function(df) {
+    if (is.data.frame(df) && "Membership" %in% colnames(df)) df$Membership <- NULL
+    df
+  }
+
   output$downloadEnrichment <- downloadHandler(
     filename = function() {
       "enrichment.csv"
     },
     content = function(file) {
-      write.csv(significantOverlaps()$x, file, row.names = FALSE)
+      write.csv(drop_membership(significantOverlaps()$x), file, row.names = FALSE)
       removeModal()
     }
   )
@@ -1062,7 +1069,7 @@ server <- function(input, output, session) {
       "enrichment_all.csv"
     },
     content = function(file) {
-      write.csv(significantOverlapsAll()$x, file, row.names = FALSE)
+      write.csv(drop_membership(significantOverlapsAll()$x), file, row.names = FALSE)
       removeModal()
     }
   )


### PR DESCRIPTION
What

Three places rebuilt pathway membership by splitting the Genes column on spaces — enrichmentPlot() (tree), enrichmentNetwork() (network), and the redundancy filter in server.R. FindOverlap() already has that membership as Ensembl IDs while it builds the string, so it now returns it as an I() list column, which stays aligned through the ordering and subsetting that follow. The three consumers read that. server.R's " |  |   " split is gone.

Why

A display column was analysis input, so reformatting it silently changed scientific output. Twice already: #84 (unique() collapsed unsymboled genes) and #86 (padded symbols became blank tokens). Both were fixed at the formatting end, leaving the mechanism intact — and 4f483bc's message shows the nzchar() check behind #86 came from the #84 fix. The fix for the first caused the second, days later, same function. That's a contract problem, not an attention problem.

Behavior change

Membership is now always Ensembl IDs. Since intersect() and union() de-duplicate, two paralogs sharing a symbol used to count as one element under the default and now count as two. Correct space — two paralogs are two loci — but a scientific decision:

- **Pathway overlap now counts paralogs separately when they share a gene symbol, rather than collapsing them into one gene. Previously, overlap values could change depending on the Genes column format selected in the download dialog; they no longer do.**

- **Results are unchanged for gene lists without symbol-sharing paralogs, which is the large majority, measured on the data113 db, after the deduplication ShinyGO already applies, this affects 0.29% of human protein-coding genes (60 genes across 24 symbols), 0.80% of mouse genes and 1.09% of maize genes. For lists containing gene families or tandem duplicates — defensins, KIRs, chemokines and similar — trees and networks will differ from previous releases, and pathways near the redundancy threshold may be added or removed.**

After converted() dedup on production data113: 60 of human's 20,342 protein-coding genes still share a symbol (0.29%); 0.80% of all mouse genes and 1.09% of all maize genes. Ordinary lists are unaffected — this matters for lists built around gene families or tandem duplicates.

Verification

Production data113: human (86,433 genes), mouse (78,298), maize (44,355).

- Invariance: on an adversarial query of symbol-sharing genes, tree and network overlaps are identical across all three genesColumnID settings: human GOBP 60 / GOMF 33, mouse GOBP 60 / GOMF 49, maize GOBP 60 / GOMF 60 / KEGG 33. The same maize fixture previously differed on 48.2% of GOBP pairs, up to 0.238 Jaccard, 15 crossing the 0.95 redundancy threshold.
- No regression: a realistic query (all genes of one mid-size KEGG pathway) gives byte-identical pathways, nGenes and Genes against unmodified v851pfe, human and mouse.
- Shape: membership length equals nGenes on every row, token counts unchanged, downloads still write 7 columns.